### PR TITLE
Resolve `Promise`s instead of returning `true`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -164,7 +164,7 @@ const updateStubs = async () => {
       },
     );
 
-    return true;
+    return Promise.resolve();
   }));
 
   promises.push(readFile(path.join(baseDir, 'stubs', 'App.stub.tsx'), {
@@ -183,7 +183,7 @@ const updateStubs = async () => {
       },
     );
 
-    return true;
+    return Promise.resolve();
   }));
 
   await Promise.all(promises);


### PR DESCRIPTION
Prefer `Promise.resolve()` to `return true;` in `updateStubs` promises.